### PR TITLE
Automatically attach pasted images on chat window

### DIFF
--- a/src/renderer/features/chat/controllers/chatWindowController.tsx
+++ b/src/renderer/features/chat/controllers/chatWindowController.tsx
@@ -121,8 +121,8 @@ export default class ChatWindowController
   };
 
   public attachFile = (files: FileList): void => {
-    for (let i = 0; i < files.length; i++) {
-      this.chatWindowService.attachFile(files[i]);
+    for (const file of files) {
+      this.chatWindowService.attachFile(file);
     }
   };
 

--- a/src/renderer/features/chat/services/chatWindowService.ts
+++ b/src/renderer/features/chat/services/chatWindowService.ts
@@ -296,6 +296,14 @@ export class ChatWindowService
   attachFile(file: File): void {
     const { files } = this.state;
 
+    if (
+      file.path && // Files from clipboard doesn't have a path
+      files?.findIndex((f) => f.file.path === file.path) !== -1
+    ) {
+      console.error('File already exists!');
+      return;
+    }
+
     let previewUrl = '';
 
     if (file.type.startsWith('image')) {

--- a/src/renderer/features/chat/services/chatWindowService.ts
+++ b/src/renderer/features/chat/services/chatWindowService.ts
@@ -300,7 +300,7 @@ export class ChatWindowService
       file.path && // Files from clipboard doesn't have a path
       files?.findIndex((f) => f.file.path === file.path) !== -1
     ) {
-      console.error('File already exists!');
+      console.log('File already exists!');
       return;
     }
 

--- a/src/renderer/features/chat/workbench/chatView.tsx
+++ b/src/renderer/features/chat/workbench/chatView.tsx
@@ -119,6 +119,30 @@ function ChatWindow({
       });
   }, []);
 
+  useEffect(() => {
+    const pasteHandler = (event: ClipboardEvent) => {
+      if (!event?.clipboardData?.items?.length) return;
+
+      // Access the clipboard data
+      const items = event.clipboardData.items;
+      const dataTransfer = new DataTransfer();
+      for (const item of items) {
+        if (item.type.startsWith('image')) {
+          const blob = item.getAsFile();
+          if (blob) dataTransfer.items.add(blob);
+        }
+      }
+
+      if (dataTransfer.files.length > 0) attachFile(dataTransfer.files);
+    };
+
+    // Attach the event listener
+    window.addEventListener('paste', pasteHandler);
+
+    // Clean up
+    return () => window.removeEventListener('paste', pasteHandler);
+  }, []);
+
   const sendMessage = useCallback(() => {
     const value = chatInputRef.current?.getValue();
     if (!value || value?.trim().length === 0) return;


### PR DESCRIPTION
# Description
- Automatically attaches image when the user pastes it on the chat window
- Prevent the user from attaching the same image/file multiple times
- Small refactor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Users can now paste images directly into the chat input.

- **Bug Fixes**
    - Added a check to prevent attaching duplicate files in chat based on file paths.

- **Refactor**
    - Improved the readability and structure of the file attachment code in chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->