### PR TITLE
fix: downgrade electron to 27.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "css-minimizer-webpack-plugin": "^6.0.0",
         "detect-port": "^1.5.1",
         "dotenv-webpack": "^8.1.0",
-        "electron": "^30.0.1",
+        "electron": "^27.3.11",
         "electron-builder": "^24.13.3",
         "electron-devtools-installer": "^3.2.0",
         "electronmon": "^2.0.3",
@@ -11458,13 +11458,13 @@
       }
     },
     "node_modules/electron": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-30.0.1.tgz",
-      "integrity": "sha512-iwxkI/n2wBd29NH7TH0ZY8aWGzCoKpzJz+D10u7aGSJi1TV6d4MSM3rWyKvT/UkAHkTKOEgYfUyCa2vWQm8L0g==",
+      "version": "27.3.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.3.11.tgz",
+      "integrity": "sha512-E1SiyEoI8iW5LW/MigCr7tJuQe7+0105UjqY7FkmCD12e2O6vtUbQ0j05HaBh2YgvkcEVgvQ2A8suIq5b5m6Gw==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^20.9.0",
+        "@types/node": "^18.11.18",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -11782,6 +11782,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "18.19.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.31.tgz",
+      "integrity": "sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/electronmon": {

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "css-minimizer-webpack-plugin": "^6.0.0",
     "detect-port": "^1.5.1",
     "dotenv-webpack": "^8.1.0",
-    "electron": "^30.0.1",
+    "electron": "^27.3.11",
     "electron-builder": "^24.13.3",
     "electron-devtools-installer": "^3.2.0",
     "electronmon": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "css-minimizer-webpack-plugin": "^6.0.0",
     "detect-port": "^1.5.1",
     "dotenv-webpack": "^8.1.0",
-    "electron": "^27.3.11",
+    "electron": "27.3.11",
     "electron-builder": "^24.13.3",
     "electron-devtools-installer": "^3.2.0",
     "electronmon": "^2.0.3",


### PR DESCRIPTION
Electron 28.x+ introduce breaking changes when running app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated Electron to a more stable version to enhance app performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->