### PR TITLE
refactor: Set text input type to password if setting is secret

### DIFF
--- a/src/renderer/components/form/form-widgets/hubaiTextWidget.tsx
+++ b/src/renderer/components/form/form-widgets/hubaiTextWidget.tsx
@@ -12,18 +12,19 @@ export default function HubaiTextWidget({
 }: WidgetProps) {
   let inputType = 'text'; // default to text input
 
-  switch (schema.type) {
-    case 'integer':
-      inputType = 'number';
-      break;
-    case 'number':
-      inputType = 'text'; // Use text input to allow floating points, validate manually
-      break;
-    default:
-      if (schema.isSecret) {
-        inputType = 'password';
-      }
-      break;
+  if (schema.isSecret) {
+    inputType = 'password';
+  } else {
+    switch (schema.type) {
+      case 'integer':
+        inputType = 'number';
+        break;
+      case 'number':
+        inputType = 'text'; // Use text input to allow floating points, validate manually
+        break;
+      default:
+        break;
+    }
   }
 
   const handleChange = useCallback(

--- a/src/renderer/components/form/form-widgets/hubaiTextWidget.tsx
+++ b/src/renderer/components/form/form-widgets/hubaiTextWidget.tsx
@@ -12,10 +12,18 @@ export default function HubaiTextWidget({
 }: WidgetProps) {
   let inputType = 'text'; // default to text input
 
-  if (schema.type === 'integer') {
-    inputType = 'number';
-  } else if (schema.type === 'number') {
-    inputType = 'text'; // Use text input to allow floating points, validate manually
+  switch (schema.type) {
+    case 'integer':
+      inputType = 'number';
+      break;
+    case 'number':
+      inputType = 'text'; // Use text input to allow floating points, validate manually
+      break;
+    default:
+      if (schema.isSecret) {
+        inputType = 'password';
+      }
+      break;
   }
 
   const handleChange = useCallback(

--- a/src/renderer/components/form/settingsMapForm.tsx
+++ b/src/renderer/components/form/settingsMapForm.tsx
@@ -59,6 +59,8 @@ export function MapSettingToSchema(setting: ISettingMap): RJSFSchema {
     defaultValueParsed = defaultValue === 'true';
   }
 
+  const isSecret = !!setting.isSecret;
+
   function getEnumValues(): string[] | undefined {
     if (typeof enumValues === 'function') {
       return enumValues?.();
@@ -74,6 +76,7 @@ export function MapSettingToSchema(setting: ISettingMap): RJSFSchema {
     enum: getEnumValues(),
     description,
     originalName: name,
+    isSecret,
   };
 
   return property;


### PR DESCRIPTION
As per issue #1, text inputs for settings with secret values are now of type password.

![image](https://github.com/gethubai/hubai-desktop/assets/1711517/96341128-a958-4734-90e3-4af14841427c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new feature to handle secret inputs, displaying them as password fields in forms.

- **Refactor**
  - Improved code readability and maintainability in the form component by refactoring conditional logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->