### PR TITLE
fix: auto update for windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,10 @@ jobs:
           AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
           AUTH0_AUDIENCE: ${{ secrets.AUTH0_AUDIENCE }}
           APP_INSIGHTS_INSTRUMENTATION_KEY: ${{ secrets.APP_INSIGHTS_INSTRUMENTATION_KEY }}
-          CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_KEY_PASSWORD }}
-          CSC_INSTALLER_LINK: ${{ secrets.APPLE_CSC_INSTALLER_LINK }}
-          CSC_INSTALLER_KEY_PASSWORD: ${{ secrets.APPLE_CSC_INSTALLER_KEY_PASSWORD }}
+          CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.APPLE_CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.APPLE_CSC_KEY_PASSWORD || '' }}
+          CSC_INSTALLER_LINK: ${{ matrix.os == 'macos-latest' && secrets.APPLE_CSC_INSTALLER_LINK || '' }}
+          CSC_INSTALLER_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.APPLE_CSC_INSTALLER_KEY_PASSWORD || '' }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}


### PR DESCRIPTION
Auto-update is not working on windows because the installer is being signed with the apple certificate.

I'm changing the workflow to only pass the `CSC_***` env vars on macOS builds.